### PR TITLE
Added trip_route IS NOT NULL in fact table

### DIFF
--- a/prefect/capital_bike_share/models/core/fact_bike_tripdata.sql
+++ b/prefect/capital_bike_share/models/core/fact_bike_tripdata.sql
@@ -22,5 +22,5 @@ FROM
     fact_bikes
 WHERE
     duration_in_seconds > 0
-    -- AND trip_route IS NOT NULL
+    AND trip_route IS NOT NULL
 


### PR DESCRIPTION
<details>
<summary>Comparison Summary</summary>

Table | Rows | Columns 
--- | --- | ---
fact_bike_tripdata | 5898521 (-329845) | 15 (+0) 


</details>
<details>
<summary>Tables Summary</summary>
<blockquote>

<details>
<summary>fact_bike_tripdata</summary>

Column | Type | Valid % | Distinct %
--- | --- | --- | ---
ride_id | VARCHAR | 100.0% (+0.0%) | 100.0% (+0.0%) 
rideable_type | VARCHAR | 100.0% (+0.0%) | 0.0% (+0.0%) 
started_at | TIMESTAMP | 100.0% (+0.0%) | 91.87% (+0.28%) 
ended_at | TIMESTAMP | 100.0% (+0.0%) | 91.61% (+0.28%) 
start_station_name | VARCHAR | 100.0% (+2.3%) | 0.01% (+0.0%) 
start_station_id | INTEGER | 100.0% (+2.3%) | 0.01% (+0.0%) 
end_station_name | VARCHAR | 100.0% (+3.0%) | 0.01% (+0.0%) 
end_station_id | INTEGER | 100.0% (+3.0%) | 0.01% (+0.0%) 
start_latitude | FLOAT | 100.0% (+0.0%) | 3.68% (-0.27%) 
start_longitude | FLOAT | 100.0% (+0.0%) | 4.05% (-0.31%) 
end_latitude | FLOAT | 100.0% (+0.18%) | 2.45% (-0.34%) 
end_longitude | FLOAT | 100.0% (+0.18%) | 2.58% (-0.38%) 
member_casual | VARCHAR | 100.0% (+0.0%) | 0.0% (+0.0%) 
duration_in_seconds | INTEGER | 100.0% (+0.0%) | 0.5% (-0.02%) 
trip_route | VARCHAR | 100.0% (+5.3%) | 2.53% (+0.0%) 

</details>
</blockquote></details>